### PR TITLE
Add Related Characters and Font Variations Inspector Views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
 name = "glyphana"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "bytemuck",


### PR DESCRIPTION
## Summary
- Introduces a new inspector view mode toggle between "Related Characters" and "Font Variations"
- Implements logic to find related characters including case variants, nearby Unicode block characters, and Latin diacritic variations
- Adds font variation display for the selected character using multiple Noto fonts (symbols, math, music, emoji)
- Enhances UI with selectable labels to switch views and grids/lists to display related characters and font previews

## Changes

### Core Functionality
- Added `InspectorViewMode` enum to track current inspector mode
- Implemented `get_related_characters` to gather related characters based on case, Unicode blocks, and diacritics
- Implemented `get_font_variations` to list fonts that support the selected character

### UI Components
- Added toggle buttons in the right panel to switch between "Related Characters" and "Font Variations"
- Created `render_related_characters` to display related characters in a clickable grid with tooltips
- Created `render_font_variations` to show the selected character rendered in different fonts with copy-on-click functionality

### State Management
- Added `inspector_view_mode` field to app state with default to `RelatedCharacters`

## Test plan
- [x] Select a character and verify related characters are displayed correctly
- [x] Switch to font variations view and confirm fonts render the character
- [x] Click related characters to update selection
- [x] Click font variation characters to copy them to clipboard
- [x] Verify UI toggles between views without errors
- [x] Confirm no regressions in existing character preview and collection features

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d50213d0-fe85-4d26-990d-8ea6bd94efac